### PR TITLE
take care of all available ios14 att status

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,10 @@ admob.getTrackingStatus().then(function(status) { // get status..
         navigator.notification.confirm(LANGUAGE.tracking_info_msg, function() { // open a native popup for infos..
 
             admob.trackingStatusForm().then(function(status) { // iOS tracking form..
-                if (status === 'authorized' || status === 'restricted') {
-                    // show ads..
+                // show ads..
 
-                }
-
-                if (status === 'restricted' || status === 'denied') {
-                    // not authorized show a motivation popup.. (optional)
+                if (status !== 'authorized') {
+                    // not authorized to track user, show a motivation popup.. (optional)
 
                     // navigator.notification.confirm..
                 }
@@ -34,16 +31,10 @@ admob.getTrackingStatus().then(function(status) { // get status..
         }, LANGUAGE.tracking_info, [LANGUAGE.okay]);
 
     } else { // determined..
-
         // show ads..
 
-        if (status === 'authorized' || status === 'restricted') {
-            // show ads..
-
-        }
-
-        if (status === 'restricted' || status === 'denied') {
-            // not authorized show a motivation popup.. (optional)
+        if (status !== 'authorized') {
+            // not authorized to track user, show a motivation popup.. (optional)
 
             // navigator.notification.confirm..
         }

--- a/README.md
+++ b/README.md
@@ -14,15 +14,18 @@ admob.banner.config({ id: admobid.banner, overlap: true, isTesting: false, autoS
 
 admob.getTrackingStatus().then(function(status) { // get status..
 
-    if (status == 'notDetermined') { // not determined..
+    if (status === 'notDetermined') { // not determined..
 
         navigator.notification.confirm(LANGUAGE.tracking_info_msg, function() { // open a native popup for infos..
 
             admob.trackingStatusForm().then(function(status) { // iOS tracking form..
+                if (status === 'authorized' || status === 'restricted') {
+                    // show ads..
 
-                // show ads..
+                }
 
-                if (status != 'authorized') { // not authorized show a motivation popup.. (optional)
+                if (status === 'restricted' || status === 'denied') {
+                    // not authorized show a motivation popup.. (optional)
 
                     // navigator.notification.confirm..
                 }
@@ -34,7 +37,13 @@ admob.getTrackingStatus().then(function(status) { // get status..
 
         // show ads..
 
-        if (status != 'authorized') { // not authorized show a motivation popup.. (optional)
+        if (status === 'authorized' || status === 'restricted') {
+            // show ads..
+
+        }
+
+        if (status === 'restricted' || status === 'denied') {
+            // not authorized show a motivation popup.. (optional)
 
             // navigator.notification.confirm..
         }

--- a/src/ios/CDVAdMob.m
+++ b/src/ios/CDVAdMob.m
@@ -201,11 +201,15 @@
             NSLog(@"Proceed to form..");
             UMPFormStatus formStatus = UMPConsentInformation.sharedInstance.formStatus;
             if (formStatus == UMPFormStatusAvailable) {
-                NSLog(@"Loading form..");
+                NSLog(@"Form status is available");
                 [self __loadForm:command];
-            } else {
+            } else if (formStatus == UMPFormStatusUnavailable) {
                 NSLog(@"Form status is not available");
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"formStatusNotAvailable"];
+                [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
+            } else if (formStatus == UMPFormStatusUnknown) {
+                NSLog(@"Form status is unknown");
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"formStatusUnknown"];
                 [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
             }
         }
@@ -228,6 +232,7 @@
             // Present the form. You can also hold on to the reference to present later.
             NSLog(@"Presenting form..");
             if (UMPConsentInformation.sharedInstance.consentStatus == UMPConsentStatusRequired) {
+                    NSLog(@"Consent Status Required");
                     [form presentFromViewController:self.viewController completionHandler:^(NSError *_Nullable dismissError) {
 
                         CDVPluginResult *pluginResult;
@@ -237,9 +242,15 @@
                             // App can start requesting ads.
                             NSLog(@"Obtained");
                             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"obtained"];
+                        } else if (UMPConsentInformation.sharedInstance.consentStatus == UMPConsentStatusRequired) {
+                            NSLog(@"Required");
+                            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"required"];
+                        } else if (UMPConsentInformation.sharedInstance.consentStatus == UMPConsentStatusNotRequired) {
+                            NSLog(@"Not Required");
+                            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"NotRequired"];
                         } else {
-                            NSLog(@"Not obtained");
-                            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"notObtained"];
+                            NSLog(@"Unknown");
+                            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:@"unknown"];
                         }
                         [self.commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
                     }];


### PR DESCRIPTION
I've updated the code to reflect all available iOS 14 ATTrackingStatus values. Not sure if it's really needed, but it may come handy if someone wants to show different messages, based on the users decision to restrict or deny access.